### PR TITLE
Corrige 2 bugs et assure les assertions de Not7Game de passer par tous les chemins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bin
 out
 FrcJavaKoans.zip
 .VSCodeCounter
+.vscode/launch.json

--- a/src/main/java/engine/Koan.java
+++ b/src/main/java/engine/Koan.java
@@ -193,24 +193,11 @@ public class Koan {
     }
 
     public Koan whenCalling() {
-        return new Koan(
-            koanClass,
-            methodName,
-            methodParamTypes,
-            constructorParamTypes,
-            constructorParams,
-            onObject,
-            new KoanTest[] { new KoanTest(this, new Object[0], constructorParams) },
-            usesConsole,
-            showStdInInputs,
-            exerciseClassName,
-            exerciseClassPackage,
-            koanAssertions
-        );
+        return whenCallingWith();
     }
 
     public Koan withStdInInputs(List<Localizable<String>> inputs) {
-        return withUpdatedTest(call -> call.withStdInInputs(inputs));
+        return withUpdatedTest(kTest -> kTest.withStdInInputs(inputs));
     }
 
     public Koan withStdInInputs(String... inputs) {
@@ -221,8 +208,12 @@ public class Koan {
         );
     }
 
+    public Koan withSeed(long seed) {
+        return withUpdatedTest(kTest -> kTest.withSeed(seed));
+    }
+
     public Koan then(ResultAssertion... assertions) {
-        return withUpdatedTest(call -> call.withAssertions(assertions));
+        return withUpdatedTest(kTest -> kTest.withAssertions(assertions));
     }
 
     public String koanClassName(Locale locale) {

--- a/src/main/java/engine/KoanTargetMethod.java
+++ b/src/main/java/engine/KoanTargetMethod.java
@@ -7,9 +7,9 @@ import java.util.Arrays;
 
 public class KoanTargetMethod {
     public final KoanTest koanTest;
-    public final Method method;
+    private final Method method;
     public final Class<?> clasz;
-    public final Object object;
+    private final Object object;
     private final Value[] localizedParams;
     private final Value[] localizedConstructorParams;
 

--- a/src/main/java/engine/KoanTest.java
+++ b/src/main/java/engine/KoanTest.java
@@ -43,6 +43,10 @@ public class KoanTest {
         return new KoanTest(koan, params, constructorParams, assertions, stdInInputs, seed);
     }
 
+    public KoanTest withSeed(long seed) {
+        return new KoanTest(koan, params, constructorParams, assertions, stdInInputs, seed);
+    }
+
     public String[] stdInInputs(Locale locale) {
         return stdInInputs.stream()
             .map(p -> p.get(locale))

--- a/src/main/java/engine/Sensei.java
+++ b/src/main/java/engine/Sensei.java
@@ -37,27 +37,38 @@ public class Sensei {
     }
 
     private boolean tryOffer(Koan koan, int successfulCount) {
+        for(var test: koan.tests) {
+            var success = tryOffer(test, successfulCount);
+            if (!success) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean tryOffer(KoanTest test, int successfulCount) {
         // Execute silently the first time.
         // We do not want to display all the outputs of the successful koans to the student.
         p = Printer.SILENT;
-        var succeeded = offer(koan, successfulCount);
+        var succeeded = offer(test, successfulCount);
 
         if (!succeeded) {
             // If failed, execute verbosely the second time, in order to give feedback to the student.
             p = consolePrinter;
-            return offer(koan, successfulCount);
+            return offer(test, successfulCount);
         }
 
         return true;
     }
 
-    private boolean offer(Koan koan, int successfulCount) {
+    private boolean offer(KoanTest test, int successfulCount) {
+        var koan = test.koan;
         observe(koan);
         encourage();
         
         var success = false;
         try {
-            success = executeCalls(koan);
+            success = executeCall(test);
         } catch (IllegalAccessException iae) {
             // Special case: since the executeCall() method did not complete, the console conclusion was not displayed.
             concludeConsole(koan);
@@ -102,17 +113,6 @@ public class Sensei {
         showProgress(successfulCount);
 
         return success;
-    }
-
-    private boolean executeCalls(Koan koan) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, ClassNotFoundException, InstantiationException {
-        for(var test: koan.tests) {
-            final var success = executeCall(test);
-            if (!success) {
-                return false;
-            }
-        }
-
-        return true;
     }
 
     private boolean executeCall(KoanTest test) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, ClassNotFoundException, InstantiationException {

--- a/src/main/java/sensei/AboutNot7GameKoans.java
+++ b/src/main/java/sensei/AboutNot7GameKoans.java
@@ -47,6 +47,10 @@ public class AboutNot7GameKoans {
             .whenCalling()
             .then(
                 assertReturnValueWithRandomEquals(rand -> die(rand))
+            )
+            .whenCalling()
+            .then(
+                assertReturnValueWithRandomEquals(rand -> die(rand))
             ),
         new Koan(CLASS, "askQuestion", String.class)
             .useConsole()
@@ -66,6 +70,12 @@ public class AboutNot7GameKoans {
             ),
         new Koan(CLASS, "throwDice")
             .useConsole()
+            .whenCalling()
+            .then(
+                assertReturnValueWithRandomEquals(2, expectedDieSumResult(0, 1)),
+                assertNextStdOutLineEquals(YOU_THREW, expectedDieResult(0), expectedDieResult(1)),
+                assertNoMoreLineInStdOut()
+            )
             .whenCalling()
             .then(
                 assertReturnValueWithRandomEquals(2, expectedDieSumResult(0, 1)),
@@ -111,11 +121,24 @@ public class AboutNot7GameKoans {
         new Koan(CLASS, "gameRoundv4")
             .useConsoleAndShowStdinInputs()
             .whenCalling()
+            .withSeed(1010) // 7 directly
+            .then(
+                AboutNot7GameKoans::gameRoundv4Assertions
+            )
+            .whenCalling()
+            .withSeed(1000) // non 7 result and n
             .withStdInInputs(List.of(N))
             .then(
                 AboutNot7GameKoans::gameRoundv4Assertions
             )
             .whenCalling()
+            .withSeed(1001) // o, o, et 7
+            .withStdInInputs(List.of(Y, Y))
+            .then(
+                AboutNot7GameKoans::gameRoundv4Assertions
+            )
+            .whenCalling()
+            .withSeed(1003) // o, o, n
             .withStdInInputs(List.of(Y, Y, N))
             .then(
                 AboutNot7GameKoans::gameRoundv4Assertions
@@ -123,17 +146,34 @@ public class AboutNot7GameKoans {
         new Koan(CLASS, "gameRoundv5")
             .useConsoleAndShowStdinInputs()
             .whenCalling()
+            .withSeed(1010) // 7 directly
             .withStdInInputs(List.of(N))
             .then(
                 new GameRoundv5Assertions(true),
                 assertNoMoreLineInStdOut()
             )
             .whenCalling()
+            .withSeed(1000) // non 7 result and n
+            .withStdInInputs(List.of(N))
+            .then(
+                new GameRoundv5Assertions(true),
+                assertNoMoreLineInStdOut()
+            )
+            .whenCalling()
+            .withSeed(1003) // o, o, n
             .withStdInInputs(List.of(Y, Y, N))
             .then(
                 new GameRoundv5Assertions(true),
                 assertNoMoreLineInStdOut()
+            )
+            .whenCalling()
+            .withSeed(1001) // o, o, et 7
+            .withStdInInputs(List.of(Y, Y))
+            .then(
+                new GameRoundv5Assertions(true),
+                assertNoMoreLineInStdOut()
             ),
+        // Since the display of who is playing is not random dependant, not using seeds here.
         new Koan(CLASS, "not7Gamev1")
             .useConsoleAndShowStdinInputs()
             .whenCalling()
@@ -158,9 +198,24 @@ public class AboutNot7GameKoans {
                 GAME_ROUND_ASSERTIONS,
                 assertNoMoreLineInStdOut()
             ),
+        // Since the display of who has won is random dependant, use seeds.
         new Koan(CLASS, "not7Gamev2")
             .useConsoleAndShowStdinInputs()
             .whenCalling()
+            .withSeed(2002) // Player 2 wins
+            .withStdInInputs(List.of(N))
+            .then(
+                assertNextStdOutLineEquals(PLAYER_1_ITS_YOUR_TURN),
+                assertNextStdOutLineIsEmpty(),
+                GAME_ROUND_ASSERTIONS,
+                assertNextStdOutLineEquals(PLAYER_2_ITS_YOUR_TURN),
+                assertNextStdOutLineIsEmpty(),
+                GAME_ROUND_ASSERTIONS,
+                AboutNot7GameKoans::assertWinnerLine,
+                assertNoMoreLineInStdOut()
+            )
+            .whenCalling()
+            .withSeed(2000) // Player 1 wins
             .withStdInInputs(List.of(N, N))
             .then(
                 assertNextStdOutLineEquals(PLAYER_1_ITS_YOUR_TURN),
@@ -173,7 +228,8 @@ public class AboutNot7GameKoans {
                 assertNoMoreLineInStdOut()
             )
             .whenCalling()
-            .withStdInInputs(List.of(Y, Y, N, Y, Y, N))
+            .withSeed(2005) // Tie
+            .withStdInInputs(List.of(N, N))
             .then(
                 assertNextStdOutLineEquals(PLAYER_1_ITS_YOUR_TURN),
                 assertNextStdOutLineIsEmpty(),


### PR DESCRIPTION
Solves #25 and #40.

Also solves undiscovered bugs in the mean time:

- Only the first test of a given koan with a `whenCalling()` call was exectuted.
- All tests of a given koan where displayed in the console, not just the failing one.